### PR TITLE
Update font to show italic and bold appropriately

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,6 +1,7 @@
-/* Copyright (c) 2017 Anish Athalye */
+/* Copyright (c) 2017 Anish Athalye, Makoto Shimazu */
 @import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro);
 @import url(https://fonts.googleapis.com/css?family=Source+Code+Pro);
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300&display=swap');
 
 /* Basic styling */
 
@@ -14,7 +15,7 @@
 html {
 /*  font-size: 14px;
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;*/
-  font-family: "Source Sans Pro", sans-serif;
+  font-family: 'Noto Sans JP', "Source Sans Pro", sans-serif;
   font-size: 14pt;
   line-height: 1.5;
 }


### PR DESCRIPTION
#18 

斜体をうまく表示できるWebフォントをデフォルトで利用できるように変更しました。
これまで等幅フォントだったのが崩れてしまう可能性がありますが、preタグやcodeタグはすくなくとも等幅フォントが維持されるはずなので大丈夫かなと思います。